### PR TITLE
Fix auto-mode-alist regex to match default

### DIFF
--- a/poly-rst.el
+++ b/poly-rst.el
@@ -79,7 +79,7 @@ away from the current location."
   :innermodes '(poly-rst-innermode))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.rst\\'" . poly-rst-mode))
+(add-to-list 'auto-mode-alist '("\\.re?st\\'" . poly-rst-mode))
 
 (provide 'poly-rst)
 ;;; poly-rst.el ends here


### PR DESCRIPTION
The regex in the unmodifed `auto-mode-alist` is `("\\.re?st\\'" . rst-mode)`