### PR TITLE
better support for choosing major mode of each programming language

### DIFF
--- a/poly-rst.el
+++ b/poly-rst.el
@@ -87,9 +87,11 @@ Find the ReST header that are AHEAD or -AHEAD number of headers
 away from the current location."
   (when (re-search-forward poly-rst-head-start-regexp nil t ahead)
     (cons (match-beginning 0)
-          (if (re-search-forward "^[ \t]*\n" nil t)
-              (match-end 0)
-            (point-max)))))
+          (match-end 0)
+          ;; (if (re-search-forward "^[ \t]*\n" nil t)
+          ;;     (match-end 0)
+          ;;   (point-max))
+          )))
 
 (defun poly-rst-mode-matcher ()
   (when (re-search-forward poly-rst-code-lang-regexp nil t 1)


### PR DESCRIPTION
Hi,

I created this PR to allow poly-rst choose the right major mode for each programming language
For example, the major mode for `ocaml` should be `tuareg-mode`.

Currently, poly-rst returns a fallback mode for OCaml.

Could you review the PR and advise if it can be merged?

Thanks!